### PR TITLE
Fixed wrong shortcut in chapters 2_3, 2_4 and 2_5 

### DIFF
--- a/tutorial/chapter_2_3.md
+++ b/tutorial/chapter_2_3.md
@@ -31,7 +31,7 @@ chapter. (select all, copy and paste have usual system level shortcuts)
 Revision
 ---------
 
-* Delete word back - `Cmd + Delete`
-* Delete word forward - `Cmd + fn + Delete`
+* Delete word back - `Option + Delete`
+* Delete word forward - `fn + Option + Delete`
 * Insert line after - `Cmd + Return`
 * Insert line before - `Cmd + Shift + Return`

--- a/tutorial/chapter_2_4.md
+++ b/tutorial/chapter_2_4.md
@@ -57,5 +57,5 @@ Revision
 
 * Delete to beginning of the line - `Cmd + Delete`
 * Delete to end of the line - `Ctrl + K`
-* Delete word back - `Cmd + Delete`
-* Delete word forward - `Cmd + fn + Delete`
+* Delete word back - `Option + Delete`
+* Delete word forward - `fn + Option + Delete`

--- a/tutorial/chapter_2_5.md
+++ b/tutorial/chapter_2_5.md
@@ -28,6 +28,6 @@ Revision
 
 * Delete to beginning of the line - `Cmd + Delete`
 * Delete to end of the line - `Ctrl + K`
-* Delete word back - `Cmd + Delete`
+* Delete word back - `Option + Delete`
 * Delete a line - `Ctrl + Shift + K`
 * Cut a line - `Cmd + X`


### PR DESCRIPTION
for Delete word back and Delete word forward.

Great tutorial!
